### PR TITLE
Fix ClanWarLeagueClanMember town hall level property

### DIFF
--- a/lib/clash_of_clans_api/models/clan_war_league_clan_member.rb
+++ b/lib/clash_of_clans_api/models/clan_war_league_clan_member.rb
@@ -5,7 +5,7 @@ module ClashOfClansApi
 		class ClanWarLeagueClanMember < Base
 			property :tag,            'tag',           required: true
 			property :name,           'name',          required: true
-			property :townhall_level, 'townhallLevel', required: true
+			property :town_hall_level, 'townHallLevel', required: true
 		end
 	end
 end


### PR DESCRIPTION
Noticed the ClanWarLeagueClanMember has an ill-defined town hall level property.

Fixed it up here.