### PR TITLE
Removes required flag from season, clans, and rounds for ClanWarLeagueGroup

### DIFF
--- a/lib/clash_of_clans_api/models/clan_war_league_group.rb
+++ b/lib/clash_of_clans_api/models/clan_war_league_group.rb
@@ -6,9 +6,9 @@ module ClashOfClansApi
 	module Models
 		class ClanWarLeagueGroup < Base
 			property :state,  'state',  required: true
-			property :season, 'season', required: true
-			property :clans,  'clans',  required: true, type: ClanWarLeagueClan
-			property :rounds, 'rounds', required: true, type: ClanWarLeagueRound
+			property :season, 'season'
+			property :clans,  'clans', type: ClanWarLeagueClan
+			property :rounds, 'rounds', type: ClanWarLeagueRound
 		end
 	end
 end


### PR DESCRIPTION
I attempted to get the current clan war league group while my clan was searching for a clan war league group and I got this error. It seems as these fields are not present while searching and therefore should not be required.

```
clash_of_clans_api/models/base.rb:93:in `validate!': The following keys are required, but missing from the model data: "season", "clans", "rounds" (ClashOfClansApi::Models::InvalidDataError)
```